### PR TITLE
chore(pnpm): selective hoisting for Electron + builder excludes

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
 shamefully-hoist=true
+
+# Ensure Electron packages are hoisted for dev/build tools compatibility
+public-hoist-pattern[]=electron
+public-hoist-pattern[]=electron-*
+public-hoist-pattern[]=@electron/*

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -4,6 +4,18 @@ directories:
   buildResources: build
 files:
   - "!**/.vscode/*"
+  - "!**/.lgtm-data/**"
+  - "!**/.github/**"
+  - "!**/.git/**"
+  - "!dist/**"
+  - "!docs/**"
+  - "!manual-tests/**"
+  - "!tests/**"
+  - "!scripts/**"
+  - "!otel/**"
+  - "!data/**"
+  - "!Telemetryplan.md"
+  - "!RELEASE_NOTES_*.md"
   - "!src/*"
   - "!electron.vite.config.{js,ts,mjs,cjs}"
   - "!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}"


### PR DESCRIPTION
Summary\n- Add pnpm selective hoisting for Electron packages in .npmrc to stabilize dev/build with electron-vite/electron-builder.\n- Exclude CI/docs/tests, previous build outputs, and .lgtm-data from packaging to avoid permission errors and reduce artifact size.\n\nDetails\n- .npmrc: public-hoist-pattern[]=electron, electron-*, @electron/* (kept shamefully-hoist=true).\n- electron-builder.yml: added excludes for .github, .git, dist, docs, manual-tests, tests, scripts, otel, data, Telemetryplan.md, RELEASE_NOTES_*.md, and .lgtm-data.\n\nVerification\n- pnpm build: main/preload/renderer bundles succeed.\n- pnpm build:unpack: creates dist/linux-unpacked successfully in this environment.\n\nNotes\n- If dev server bind fails on ::1, run with: pnpm dev -- --host 127.0.0.1 --sourcemap.\n- If Electron binary is missing on a fresh env: node node_modules/.pnpm/electron@34.5.8/node_modules/electron/install.js.