### PR TITLE
ci(windows): prebuild native deps + debug logs for electron-builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,11 @@ jobs:
         shell: bash
         run: rm -rf dist
 
+      - name: Prebuild native deps (Windows pnpm)
+        if: matrix.os == 'windows-latest' && matrix.package-manager == 'pnpm'
+        shell: bash
+        run: pnpm exec electron-builder install-app-deps
+
       - name: Build Electron app (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         shell: bash
@@ -150,6 +155,8 @@ jobs:
         shell: bash
         env:
           USE_HARD_LINKS: false
+          DEBUG: electron-builder
+          ELECTRON_BUILDER_DEBUG: true
         run: |
           if [ "${{ matrix.package-manager }}" = "pnpm" ]; then
             pnpm exec electron-builder --win --publish never


### PR DESCRIPTION
## CI (Windows + pnpm)

Improve reliability and diagnostics for Windows packaging when using pnpm.

### Changes
- Prebuild native deps on Windows (pnpm only):
  - `pnpm exec electron-builder install-app-deps`
- Enable debug logs for electron-builder on Windows:
  - `DEBUG=electron-builder`
  - `ELECTRON_BUILDER_DEBUG=true`
- Keep `USE_HARD_LINKS=false` to avoid hardlink issues on runners.

### Expected Outcome
- Stabilize Windows packaging with pnpm or, at minimum, surface clearer errors for root-cause analysis.
