### PR TITLE
Delay renderer telemetry until preload initialization

### DIFF
--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -171,6 +171,13 @@ const initializePreload = async () => {
     }
 
     console.log("[Preload]: Initialization complete");
+    try {
+      // Notify the renderer process that preload work is finished
+      window.__KT_PRELOAD_READY__ = true;
+      window.dispatchEvent(new Event("preload-ready"));
+    } catch (e) {
+      console.warn("[Preload]: Failed to dispatch preload-ready event:", e);
+    }
   } catch (error) {
     console.error("[Preload]: Initialization failed:", error);
   }

--- a/src/renderer/src/main.jsx
+++ b/src/renderer/src/main.jsx
@@ -1,8 +1,15 @@
-import './telemetry/webTracing';
 import "./assets/styles/main.scss";
 
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+
+// Load telemetry only after the preload script has finished initializing
+const loadTelemetry = () => import("./telemetry/webTracing");
+if (window.__KT_PRELOAD_READY__) {
+  loadTelemetry();
+} else {
+  window.addEventListener("preload-ready", loadTelemetry, { once: true });
+}
 
 ReactDOM.createRoot(document.getElementById("root")).render(<App />);


### PR DESCRIPTION
## Summary
- signal when preload finishes via global flag and `preload-ready` event
- dynamically import renderer telemetry after preload is ready

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4ba8d940c8331b4bb3b8c70f513e6