### PR TITLE
feat: add support event message toggle

### DIFF
--- a/src/renderer/src/assets/styles/components/Chat/Message.scss
+++ b/src/renderer/src/assets/styles/components/Chat/Message.scss
@@ -548,6 +548,23 @@
 }
 
 /** [End of Mod Action Message] **/
+
+.supportEvent {
+  background: rgba(255, 255, 255, 0.05) !important;
+}
+
+.supportEventMessage {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 2px 8px;
+  border-radius: 4px;
+
+  .supportEventUsername {
+    font-weight: 600;
+    margin-right: 4px;
+  }
+}
+
 .tooltipItem {
   display: none;
   border-radius: 8px;

--- a/src/renderer/src/components/Dialogs/Settings.jsx
+++ b/src/renderer/src/components/Dialogs/Settings.jsx
@@ -460,6 +460,36 @@ const Settings = () => {
                         />
                       </div>
                     </div>
+                    <div className="settingsItem">
+                      <div
+                        className={clsx("settingSwitchItem", {
+                          active: settingsData?.chatrooms?.showSupportEvents,
+                        })}>
+                        <div className="settingsItemTitleWithInfo">
+                          <span className="settingsItemTitle">Show Support Events</span>
+                          <Tooltip delayDuration={100}>
+                            <TooltipTrigger asChild>
+                              <button className="settingsInfoIcon">
+                                <img src={InfoIcon} width={14} height={14} alt="Info" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Display subscription, donation, and reward events in chat</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+
+                        <Switch
+                          checked={settingsData?.chatrooms?.showSupportEvents || false}
+                          onCheckedChange={(checked) =>
+                            changeSetting("chatrooms", {
+                              ...settingsData?.chatrooms,
+                              showSupportEvents: checked,
+                            })
+                          }
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div className="settingsContentSection">

--- a/src/renderer/src/components/Dialogs/Settings/Sections/General.jsx
+++ b/src/renderer/src/components/Dialogs/Settings/Sections/General.jsx
@@ -425,6 +425,36 @@ const ChatroomSection = ({ settingsData, onChange }) => {
         <div className="settingsItem">
           <div
             className={clsx("settingSwitchItem", {
+              active: settingsData?.chatrooms?.showSupportEvents,
+            })}>
+            <div className="settingsItemTitleWithInfo">
+              <span className="settingsItemTitle">Show Support Events</span>
+              <Tooltip delayDuration={100}>
+                <TooltipTrigger asChild>
+                  <button className="settingsInfoIcon">
+                    <img src={InfoIcon} width={14} height={14} alt="Info" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Display subscription, donation, and reward events in chat</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+
+            <Switch
+              checked={settingsData?.chatrooms?.showSupportEvents || false}
+              onCheckedChange={(checked) =>
+                onChange("chatrooms", {
+                  ...settingsData?.chatrooms,
+                  showSupportEvents: checked,
+                })
+              }
+            />
+          </div>
+        </div>
+        <div className="settingsItem">
+          <div
+            className={clsx("settingSwitchItem", {
               active: settingsData?.chatrooms?.showInfoBar,
             })}>
             <div className="settingsItemTitleWithInfo">

--- a/src/renderer/src/components/Messages/Message.jsx
+++ b/src/renderer/src/components/Messages/Message.jsx
@@ -9,6 +9,7 @@ import useCosmeticsStore from "../../providers/CosmeticsProvider";
 import useChatStore from "../../providers/ChatProvider";
 import ReplyMessage from "./ReplyMessage";
 import { createMentionRegex } from "@utils/regex";
+import SupportEventMessage from "./SupportEventMessage";
 
 import {
   ContextMenu,
@@ -104,6 +105,20 @@ const Message = ({
     }
     return "transparent";
   };
+
+  const parsedMetadata = useMemo(() => {
+    if (typeof message?.metadata === "string") {
+      try {
+        return JSON.parse(message.metadata);
+      } catch {
+        return {};
+      }
+    }
+    return message?.metadata || {};
+  }, [message?.metadata]);
+
+  const eventType = message?.type === "metadata" ? parsedMetadata?.type : message?.type;
+  const isSupportEvent = ["subscription", "donation", "reward"].includes(eventType);
 
   // Remove useCallback for these since message changes constantly
   const handleCopyMessage = () => {
@@ -321,6 +336,7 @@ const Message = ({
         shouldHighlightMessage && "highlighted",
         message.isOptimistic && message.state === "optimistic" && "optimistic",
         message.isOptimistic && message.state === "failed" && "failed",
+        isSupportEvent && "supportEvent",
       )}
       style={{
         backgroundColor: shouldHighlightMessage ? rgbaObjectToString(settings?.notifications?.backgroundRgba) : "transparent",
@@ -386,6 +402,8 @@ const Message = ({
           userChatroomInfo={userChatroomInfo}
         />
       )}
+
+      {isSupportEvent && <SupportEventMessage message={{ ...message, metadata: parsedMetadata }} />}
     </div>
   );
 

--- a/src/renderer/src/components/Messages/MessagesHandler.jsx
+++ b/src/renderer/src/components/Messages/MessagesHandler.jsx
@@ -101,6 +101,21 @@ const MessagesHandler = memo(
           return false;
         }
 
+        let metadata = {};
+        if (typeof message?.metadata === "string") {
+          try {
+            metadata = JSON.parse(message.metadata);
+          } catch {
+            metadata = {};
+          }
+        } else {
+          metadata = message?.metadata || {};
+        }
+        const eventType = message?.type === "metadata" ? metadata?.type : message?.type;
+        if (["subscription", "donation", "reward"].includes(eventType) && !settings?.chatrooms?.showSupportEvents) {
+          return false;
+        }
+
         return (
           <Message
             key={message?.id}

--- a/src/renderer/src/components/Messages/SupportEventMessage.jsx
+++ b/src/renderer/src/components/Messages/SupportEventMessage.jsx
@@ -1,0 +1,16 @@
+import { memo } from "react";
+
+const SupportEventMessage = memo(({ message }) => {
+  const metadata = message?.metadata || {};
+  const username = metadata.username || message?.sender?.username || "";
+  const description = metadata.message || metadata.description || message?.content || "";
+
+  return (
+    <span className="supportEventMessage">
+      {username && <span className="supportEventUsername">{username}</span>}
+      {description && <span className="supportEventDescription">{description}</span>}
+    </span>
+  );
+});
+
+export default SupportEventMessage;

--- a/utils/config.js
+++ b/utils/config.js
@@ -50,6 +50,10 @@ const schema = {
         type: "boolean",
         default: true,
       },
+      showSupportEvents: {
+        type: "boolean",
+        default: true,
+      },
       batchingInterval: {
         type: "number",
         default: 0,
@@ -67,6 +71,7 @@ const schema = {
     },
     default: {
       showModActions: true,
+      showSupportEvents: true,
       batchingInterval: 0,
       batching: false,
       showInfoBar: true,

--- a/utils/services/kick/kickPusher.js
+++ b/utils/services/kick/kickPusher.js
@@ -364,7 +364,8 @@ class KickPusher extends EventTarget {
           jsonData.event === `App\\Events\\ChatMessageEvent` ||
           jsonData.event === `App\\Events\\MessageDeletedEvent` ||
           jsonData.event === `App\\Events\\UserBannedEvent` ||
-          jsonData.event === `App\\Events\\UserUnbannedEvent`
+          jsonData.event === `App\\Events\\UserUnbannedEvent` ||
+          /Subscription|Donation|Tip|Reward/.test(jsonData.event)
         ) {
           // Record received message for ChatMessageEvent
           if (jsonData.event === `App\\Events\\ChatMessageEvent`) {

--- a/utils/services/kick/sharedKickPusher.js
+++ b/utils/services/kick/sharedKickPusher.js
@@ -281,7 +281,8 @@ class SharedKickPusher extends EventTarget {
           jsonData.event === `App\\Events\\ChatMessageEvent` ||
           jsonData.event === `App\\Events\\MessageDeletedEvent` ||
           jsonData.event === `App\\Events\\UserBannedEvent` ||
-          jsonData.event === `App\\Events\\UserUnbannedEvent`
+          jsonData.event === `App\\Events\\UserUnbannedEvent` ||
+          /Subscription|Donation|Tip|Reward/.test(jsonData.event)
         ) {
           const chatroomId = this.extractChatroomIdFromChannel(jsonData.channel);
           if (chatroomId) {


### PR DESCRIPTION
## Summary
- style subscription, donation, and reward events with custom background
- allow users to hide or show support events
- handle receiving subscription, donation, and reward events from Kick

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba26fb56c0833198caf45126aadeb7