### PR TITLE
feat: implement resizable split pane functionality

### DIFF
--- a/docs/Architecture-Overview.md
+++ b/docs/Architecture-Overview.md
@@ -1,0 +1,243 @@
+# KickTalk Architecture Overview
+
+## Application Structure
+
+KickTalk is an Electron-based desktop chat client for Kick.com, built with electron-vite, React, and comprehensive OpenTelemetry observability.
+
+## High-Level Architecture
+
+### Process Architecture
+
+KickTalk follows Electron's multi-process architecture with enhanced telemetry and monitoring:
+
+- **Main Process**: Node.js process managing application lifecycle, window management, system integration, and telemetry collection
+- **Renderer Process**: Chromium process running the React frontend with isolated preload bridge
+- **Preload Bridge**: Secure IPC communication layer with context isolation
+
+### Core Technology Stack
+
+- **Framework**: Electron with electron-vite for build tooling
+- **Frontend**: React 18 with functional components and hooks
+- **State Management**: Zustand for chat state, React Context for settings
+- **Styling**: SCSS with component-scoped stylesheets
+- **Real-time Communication**: WebSocket (Pusher protocol) for Kick.com integration
+- **Observability**: OpenTelemetry with Grafana Cloud integration
+- **Build System**: Vite for fast development and optimized builds
+
+## Detailed Architecture Components
+
+### 1. Frontend (Renderer Process)
+
+#### Component Hierarchy
+
+The application uses a single-page architecture without routing:
+
+```
+App
+├── ErrorBoundary
+├── Loader
+├── SettingsProvider
+│   ├── ChatHistorySettingsSync
+│   └── ChatPage
+│       ├── TitleBar
+│       ├── chatWrapper
+│       │   ├── Navbar (Chatroom Tabs)
+│       │   └── chatContent
+│       │       ├── PanelGroup (Resizable Panels)
+│       │       │   ├── Panel (Main Chat)
+│       │       │   │   ├── Chat Component
+│       │       │   │   │   ├── StreamerInfo
+│       │       │   │   │   ├── MessagesHandler
+│       │       │   │   │   ├── Input
+│       │       │   │   │   ├── Pin
+│       │       │   │   │   ├── Poll
+│       │       │   │   │   └── Predictions
+│       │       │   │   └── Mentions Dialog
+│       │       │   └── Panel[] (Split Pane Chats)
+│       │       │       └── SplitPaneChat
+```
+
+#### State Management
+
+- **ChatProvider (Zustand)**: Global chat state, chatroom management, message handling
+- **SettingsProvider (React Context)**: User preferences, theme settings, feature flags
+- **CosmeticsProvider (React Context)**: 7TV emotes, BTTV integration, custom cosmetics
+
+#### Key Components
+
+- **Chat/**: Main chat interface with message rendering, input handling, and streamer information
+- **Messages/**: Message components for different types (chat, donations, subscriptions, system)
+- **Dialogs/**: Modal dialogs for mentions, settings, user profiles, auth
+- **Navbar/**: Channel navigation with tab management
+- **Cosmetics/**: Emote rendering, badges, custom chat enhancements
+
+### 2. Backend (Main Process)
+
+#### Core Services
+
+The main process provides comprehensive services through IPC handlers:
+
+- **Window Management**: Multiple dialog windows (settings, user profiles, auth, search, reply threads)
+- **Data Persistence**: Electron-store integration for settings and authentication
+- **System Integration**: System tray, notifications, auto-updater
+- **External Tools**: Streamlink integration for stream playback
+- **Chat Logging**: Persistent chat history with search capabilities
+- **Telemetry**: OpenTelemetry metrics collection and export
+
+#### Telemetry Architecture
+
+Comprehensive observability system with multiple specialized modules:
+
+- **Core Metrics** (`telemetry/metrics.js`): Application performance and usage metrics
+- **Distributed Tracing** (`telemetry/tracing.js`): Request tracing across components
+- **Error Monitoring** (`telemetry/error-monitoring.js`): Error tracking with recovery strategies
+- **SLO Monitoring** (`telemetry/slo-monitoring.js`): Service Level Objective tracking
+- **User Analytics** (`telemetry/user-analytics.js`): User behavior and engagement tracking
+- **Performance Budget** (`telemetry/performance-budget.js`): Performance threshold monitoring
+
+### 3. Real-time Communication Layer
+
+#### WebSocket Services
+
+- **Shared Kick Pusher** (`utils/services/kick/sharedKickPusher.js`): Primary WebSocket service handling multiple chatrooms through a single connection
+- **Individual Kick Pusher** (`utils/services/kick/kickPusher.js`): Legacy per-chatroom connections
+- **7TV WebSocket** (`utils/services/seventv/sharedStvWebSocket.js`): Real-time emote and cosmetic updates
+- **Connection Manager** (`utils/services/connectionManager.js`): Orchestrates all WebSocket connections
+
+#### API Integration
+
+- **Kick API** (`utils/services/kick/kickAPI.js`): Complete REST API integration for user actions, moderation, channel data
+- **7TV API**: Emote sets, user cosmetics, and badges integration
+
+### 4. IPC Bridge (Preload)
+
+Secure communication bridge between main and renderer processes with:
+
+- **Context Isolation**: Prevents direct Node.js access from renderer
+- **Type Safety**: Structured API surface with parameter validation
+- **Error Handling**: Graceful degradation when services are unavailable
+- **Telemetry Integration**: IPC method tracking and performance monitoring
+
+## Data Flow Architecture
+
+### Chat Message Flow
+
+1. **WebSocket Receipt**: Pusher receives message from Kick servers
+2. **Event Processing**: Message parsed and validated in connection service
+3. **State Update**: ChatProvider updates Zustand store
+4. **UI Render**: React components re-render with new message data
+5. **Persistence**: Message logged to main process storage
+6. **Telemetry**: Message metrics recorded for analytics
+
+### User Action Flow
+
+1. **UI Interaction**: User triggers action in React component
+2. **IPC Call**: Renderer calls main process via preload bridge
+3. **Service Execution**: Main process executes action (API call, system integration)
+4. **Response Handling**: Success/error response sent back to renderer
+5. **State Update**: UI state updated based on response
+6. **Telemetry**: Action performance and success metrics recorded
+
+## Security Architecture
+
+### Process Isolation
+
+- **Context Isolation**: Renderer process cannot access Node.js APIs directly
+- **Secure IPC**: All communication through controlled preload bridge
+- **CSP Headers**: Content Security Policy prevents code injection
+- **Sandbox Mode**: Renderer runs in sandboxed environment
+
+### Data Protection
+
+- **Token Storage**: Secure storage of authentication tokens using electron-store encryption
+- **Request Validation**: All API requests validated and sanitized
+- **Error Sanitization**: Sensitive data stripped from error messages
+- **HTTPS Enforcement**: All external communications use HTTPS
+
+## Performance Architecture
+
+### Optimization Strategies
+
+- **Code Splitting**: Vite-based dynamic imports for reduced bundle size
+- **Virtual Scrolling**: Efficient rendering of large message lists
+- **Connection Pooling**: Shared WebSocket connections reduce overhead
+- **Memory Management**: Automatic message cleanup and garbage collection
+- **Telemetry-Driven**: Performance monitoring guides optimization decisions
+
+### Performance Budgets
+
+Monitored performance thresholds:
+
+- **UI Interaction**: <100ms good, <250ms acceptable
+- **Component Render**: <16ms for smooth 60fps
+- **Memory Usage**: <200MB good, <500MB acceptable
+- **WebSocket Latency**: <50ms good, <100ms acceptable
+- **Bundle Size**: <1MB good, <2MB acceptable
+
+## Deployment Architecture
+
+### Development
+
+- **electron-vite**: Fast development server with HMR
+- **Source Maps**: Full debugging support
+- **Live Reload**: Automatic recompilation and reload
+- **Telemetry Testing**: Local telemetry collection for development
+
+### Production
+
+- **Electron Builder**: Multi-platform desktop app packaging
+- **Auto-Updater**: Seamless application updates
+- **Error Reporting**: Production error collection via telemetry
+- **Performance Monitoring**: Real-time performance tracking in production
+
+## Directory Structure
+
+```
+src/
+├── main/                    # Main process (Node.js)
+│   ├── index.js            # Application entry point and IPC handlers
+│   └── utils/              # Main process utilities
+├── preload/                # IPC bridge layer
+│   └── index.js            # Secure API exposure to renderer
+├── renderer/               # Frontend (React)
+│   └── src/
+│       ├── components/     # React components
+│       ├── providers/      # State management contexts
+│       ├── pages/          # Page-level components
+│       ├── telemetry/      # Frontend telemetry helpers
+│       └── utils/          # Frontend utilities
+└── telemetry/              # Shared telemetry services
+    ├── metrics.js          # Core metrics collection
+    ├── tracing.js          # Distributed tracing
+    ├── user-analytics.js   # User behavior analytics
+    └── performance-budget.js # Performance monitoring
+
+utils/                      # Shared utilities and services
+├── services/               # External service integrations
+│   ├── kick/              # Kick.com API and WebSocket
+│   ├── seventv/           # 7TV integration
+│   └── connectionManager.js # Connection orchestration
+└── helpers/               # Utility functions
+
+docs/                      # Documentation
+├── kick-websocket-channels.md # WebSocket integration guide
+├── Phase4-UserAnalytics-Guide.md # Analytics implementation
+└── Release-notes-*.md     # Version release notes
+```
+
+## Integration Points
+
+### External Services
+
+- **Kick.com**: Primary chat platform integration
+- **7TV**: Custom emotes and cosmetics
+- **Grafana Cloud**: Telemetry data export and monitoring
+- **Streamlink**: External stream viewing integration
+
+### System Integration
+
+- **Operating System**: Native window management, system tray, notifications
+- **File System**: Chat logging, settings persistence, cache management
+- **Network**: WebSocket connections, HTTP API calls, telemetry export
+
+This architecture provides a robust, observable, and maintainable foundation for KickTalk's desktop chat client functionality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kick-talk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kick-talk",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
@@ -41,6 +41,7 @@
         "react": "^18.3.1",
         "react-colorful": "^5.6.1",
         "react-dom": "^18.3.1",
+        "react-resizable-panels": "^3.0.6",
         "react-router-dom": "^7.4.0",
         "react-virtuoso": "^4.12.7",
         "tldts": "^7.0.7",
@@ -10268,6 +10269,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.6.tgz",
+      "integrity": "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react": "^18.3.1",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.3.1",
+    "react-resizable-panels": "^3.0.6",
     "react-router-dom": "^7.4.0",
     "react-virtuoso": "^4.12.7",
     "tldts": "^7.0.7",

--- a/src/renderer/src/assets/styles/components/Chat/Input.scss
+++ b/src/renderer/src/assets/styles/components/Chat/Input.scss
@@ -12,7 +12,7 @@
   padding-top: 8px;
 
   > .chatInputContainer {
-    width: calc(100vw - 16px);
+    width: calc(100% - 16px);
     margin-bottom: 8px;
     margin-top: -1px;
     display: flex;

--- a/src/renderer/src/assets/styles/components/Navbar.scss
+++ b/src/renderer/src/assets/styles/components/Navbar.scss
@@ -31,6 +31,13 @@
     height: auto;
     align-items: center;
     padding-right: 132px;
+
+    .chatroomsContainer {
+      display: flex;
+      gap: 12px;
+      height: auto;
+      align-items: center;
+    }
   }
 
   &.wrapChatroomList {
@@ -43,6 +50,12 @@
       padding: 16px 8px;
       align-items: flex-start;
       width: 100%;
+
+      .chatroomsContainer {
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: flex-start;
+      }
 
       .navbarAddChatroomContainer {
         position: relative;
@@ -62,6 +75,42 @@
 
           &:hover {
             background-color: rgba(255, 255, 255, 0.2);
+          }
+
+          span {
+            display: none;
+          }
+        }
+      }
+
+      .splitPaneDropZoneContainer {
+        position: relative;
+        background: none;
+        height: 40px;
+        width: 40px;
+        padding: 0;
+        flex-shrink: 0; // Prevent container from shrinking during drag
+
+        .splitPaneDropZone {
+          position: absolute;
+          top: 0;
+          left: 0;
+          height: 40px;
+          width: 40px;
+          padding: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          background: transparent;
+          border: 2px solid transparent;
+          color: rgba(255, 255, 255, 0.3);
+          cursor: default;
+          transition: border 0.2s ease-in-out, background 0.2s ease-in-out, color 0.2s ease-in-out;
+
+          &.active {
+            border: 2px dashed rgba(255, 255, 255, 0.4);
+            background: rgba(255, 255, 255, 0.2);
+            color: rgba(255, 255, 255, 0.8);
           }
 
           span {
@@ -608,5 +657,50 @@
   100% {
     transform: translate(-50%, -50%);
     opacity: 1;
+  }
+}
+
+// Split Pane Drop Zone - styled like navbarAddChatroomContainer
+.splitPaneDropZoneContainer {
+  position: relative;
+  background: none;
+  height: 32px;
+  width: 80px;
+  padding: 0;
+  flex-shrink: 0; // Prevent container from shrinking during drag
+}
+
+.splitPaneDropZone {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 32px;
+  padding: 1px 16px;
+  font-size: 15px;
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  border-radius: 4px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.3);
+  border: 2px solid transparent;
+  cursor: default;
+  transition: border 0.2s ease-in-out, background 0.2s ease-in-out, color 0.2s ease-in-out;
+  user-select: none;
+  width: 80px; // Fixed width
+
+  &.active {
+    border: 2px dashed rgba(255, 255, 255, 0.4);
+    background: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  svg {
+    flex-shrink: 0;
+    pointer-events: none; // Prevent svg from interfering with drag
+  }
+
+  &.active svg {
+    transform: scale(1.1);
   }
 }

--- a/src/renderer/src/assets/styles/components/SplitPaneChat.scss
+++ b/src/renderer/src/assets/styles/components/SplitPaneChat.scss
@@ -1,0 +1,118 @@
+.splitPaneChat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-primary);
+  border-left: 1px solid var(--border-primary);
+}
+
+.splitPaneChatHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  min-height: 44px;
+  flex-shrink: 0;
+}
+
+.splitPaneChatTitleContainer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0; // Allow text truncation
+}
+
+.splitPaneChatProfileImage {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.splitPaneChatTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.splitPaneLiveIndicator {
+  background: var(--color-live);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.splitPaneChatClose {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+.splitPaneChatContent {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+// Empty state for missing chatrooms
+.splitPaneChatEmpty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 14px;
+  text-align: center;
+  padding: 20px;
+
+  p {
+    margin: 0;
+  }
+}
+
+// Responsive adjustments for narrow panels
+@media (max-width: 400px) {
+  .splitPaneChatHeader {
+    padding: 6px 8px;
+  }
+
+  .splitPaneChatTitle {
+    font-size: 13px;
+  }
+
+  .splitPaneLiveIndicator {
+    font-size: 9px;
+    padding: 1px 4px;
+  }
+}

--- a/src/renderer/src/assets/styles/pages/ChatPage.scss
+++ b/src/renderer/src/assets/styles/pages/ChatPage.scss
@@ -191,6 +191,15 @@
         opacity: 0.5;
       }
     }
+
+    .splitPaneCloseBtn {
+      opacity: 0.5;
+      transition: opacity 0.2s ease;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
   }
 }
 
@@ -829,5 +838,38 @@
   }
   100% {
     opacity: 1;
+  }
+}
+
+/** [Split Pane Resizable Panels] **/
+.chatPanels {
+  height: 100%;
+  width: 100%;
+}
+
+.resize-handle {
+  width: 4px;
+  background: var(--border-primary);
+  cursor: col-resize;
+  position: relative;
+  transition: background-color 0.2s ease-in-out;
+
+  &:hover {
+    background: var(--accent-color);
+  }
+
+  &:active {
+    background: var(--accent-color);
+  }
+
+  // Add a larger hover area for easier interaction
+  &::before {
+    content: '';
+    position: absolute;
+    left: -4px;
+    right: -4px;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
   }
 }

--- a/src/renderer/src/components/Chat/StreamerInfo.jsx
+++ b/src/renderer/src/components/Chat/StreamerInfo.jsx
@@ -3,7 +3,7 @@ import { useShallow } from "zustand/shallow";
 import clsx from "clsx";
 import useChatStore from "../../providers/ChatProvider";
 import { useAllStvEmotes } from "./hooks/useAllStvEmotes";
-import { PushPinIcon, UserIcon, Sword } from "@phosphor-icons/react";
+import { PushPinIcon, UserIcon, Sword, XIcon } from "@phosphor-icons/react";
 // import PollIcon from "../../assets/icons/poll-fill.svg?asset";
 import Pin from "./Pin";
 // import Poll from "./Poll";
@@ -17,7 +17,7 @@ import {
 } from "../Shared/ContextMenu";
 
 const StreamerInfo = memo(
-  ({ streamerData, isStreamerLive, chatroomId, userChatroomInfo, settings, updateSettings, handleSearch }) => {
+  ({ streamerData, isStreamerLive, chatroomId, userChatroomInfo, settings, updateSettings, handleSearch, showCloseButton, onClose }) => {
     const [showPinnedMessage, setShowPinnedMessage] = useState(true);
     // const [showPollMessage, setShowPollMessage] = useState(false);
     const [showStreamerCard, setShowStreamerCard] = useState(false);
@@ -161,6 +161,15 @@ const StreamerInfo = memo(
                   className={clsx("pinnedMessageBtn", pinDetails && "show", showPinnedMessage && "open")}
                   onClick={() => setShowPinnedMessage(!showPinnedMessage)}>
                   <PushPinIcon size={20} aria-label="Pin Message" />
+                </button>
+              )}
+
+              {showCloseButton && (
+                <button
+                  className="splitPaneCloseBtn"
+                  onClick={onClose}
+                  aria-label="Close split pane">
+                  <XIcon size={20} />
                 </button>
               )}
 

--- a/src/renderer/src/components/Chat/index.jsx
+++ b/src/renderer/src/components/Chat/index.jsx
@@ -11,7 +11,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import StreamerInfo from "./StreamerInfo";
 dayjs.extend(relativeTime);
 
-const Chat = ({ chatroomId, kickUsername, kickId, settings, updateSettings }) => {
+const Chat = ({ chatroomId, kickUsername, kickId, settings, updateSettings, showCloseButton, onClose }) => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
 
   const chatroom = useChatStore((state) => state.chatrooms.filter((chatroom) => chatroom.id === chatroomId)[0]);
@@ -73,6 +73,8 @@ const Chat = ({ chatroomId, kickUsername, kickId, settings, updateSettings }) =>
         settings={settings}
         handleSearch={handleSearch}
         updateSettings={updateSettings}
+        showCloseButton={showCloseButton}
+        onClose={onClose}
       />
 
       <div className="chatBody">

--- a/src/renderer/src/components/SplitPaneChat.jsx
+++ b/src/renderer/src/components/SplitPaneChat.jsx
@@ -1,0 +1,44 @@
+import "@assets/styles/components/SplitPaneChat.scss";
+import { XIcon } from "@phosphor-icons/react";
+import Chat from "./Chat";
+import useChatStore from "../providers/ChatProvider";
+
+const SplitPaneChat = ({ chatroomId, kickUsername, kickId, settings, updateSettings, onClose }) => {
+  const chatroom = useChatStore((state) => state.chatrooms.find((room) => room.id === chatroomId));
+
+  if (!chatroom) {
+    return (
+      <div className="splitPaneChat">
+        <div className="splitPaneChatHeader">
+          <span className="splitPaneChatTitle">Chatroom not found</span>
+          <button className="splitPaneChatClose" onClick={onClose} aria-label="Close split pane">
+            <XIcon size={16} />
+          </button>
+        </div>
+        <div className="splitPaneChatContent">
+          <div className="splitPaneChatEmpty">
+            <p>This chatroom is no longer available.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="splitPaneChat">
+      <div className="splitPaneChatContent">
+        <Chat
+          chatroomId={chatroomId}
+          kickUsername={kickUsername}
+          kickId={kickId}
+          settings={settings}
+          updateSettings={updateSettings}
+          showCloseButton={true}
+          onClose={onClose}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SplitPaneChat;

--- a/src/renderer/src/pages/ChatPage.jsx
+++ b/src/renderer/src/pages/ChatPage.jsx
@@ -1,11 +1,13 @@
 import "@assets/styles/pages/ChatPage.scss";
-import { useState, useEffect } from "react";
+import { useState, useEffect, Fragment } from "react";
 import { useSettings } from "../providers/SettingsProvider";
 import useChatStore from "../providers/ChatProvider";
 import Chat from "../components/Chat";
 import Navbar from "../components/Navbar";
 import TitleBar from "../components/TitleBar";
 import Mentions from "../components/Dialogs/Mentions";
+import SplitPaneChat from "../components/SplitPaneChat";
+import { PanelGroup, Panel, PanelResizeHandle } from "react-resizable-panels";
 
 // Telemetry monitoring hook
 const useTelemetryMonitoring = () => {
@@ -75,12 +77,24 @@ const endSpanError = (span, err) => {
 const ChatPage = () => {
   const { settings, updateSettings } = useSettings();
   const setCurrentChatroom = useChatStore((state) => state.setCurrentChatroom);
+  const splitPaneChatrooms = useChatStore((state) => state.splitPaneChatrooms);
+  const removeFromSplitPane = useChatStore((state) => state.removeFromSplitPane);
 
   const [activeChatroomId, setActiveChatroomId] = useState(null);
   const kickUsername = localStorage.getItem("kickUsername");
   const kickId = localStorage.getItem("kickId");
   
   // Instrumented chatroom switching with telemetry
+  // Handle closing main panel when there are split panes
+  const handleCloseMainPanel = () => {
+    if (splitPaneChatrooms.length > 0) {
+      // Make the first split pane the new main panel
+      const newMainChatroomId = splitPaneChatrooms[0];
+      removeFromSplitPane(newMainChatroomId);
+      handleChatroomSwitch(newMainChatroomId);
+    }
+  };
+
   const handleChatroomSwitch = (newChatroomId) => {
     const switchSpan = startSpan('chatroom.switch', {
       'chatroom.from': activeChatroomId || 'none',
@@ -143,22 +157,44 @@ const ChatPage = () => {
         </div>
 
         <div className="chatContent">
-          {activeChatroomId && activeChatroomId !== "mentions" ? (
-            <Chat
-              chatroomId={activeChatroomId}
-              kickUsername={kickUsername}
-              kickId={kickId}
-              settings={settings}
-              updateSettings={updateSettings}
-            />
-          ) : activeChatroomId === "mentions" ? (
-            <Mentions setActiveChatroom={setActiveChatroomId} chatroomId={activeChatroomId} />
-          ) : (
-            <div className="chatroomsEmptyState">
-              <h1>No Chatrooms</h1>
-              <p>Add a chatroom by using "CTRL"+"t" or clicking Add button</p>
-            </div>
-          )}
+          <PanelGroup direction="horizontal" className="chatPanels">
+            <Panel defaultSize={splitPaneChatrooms.length > 0 ? 60 : 100} minSize={25}>
+              {activeChatroomId && activeChatroomId !== "mentions" ? (
+                <Chat
+                  chatroomId={activeChatroomId}
+                  kickUsername={kickUsername}
+                  kickId={kickId}
+                  settings={settings}
+                  updateSettings={updateSettings}
+                  showCloseButton={splitPaneChatrooms.length > 0}
+                  onClose={handleCloseMainPanel}
+                />
+              ) : activeChatroomId === "mentions" ? (
+                <Mentions setActiveChatroom={setActiveChatroomId} chatroomId={activeChatroomId} />
+              ) : (
+                <div className="chatroomsEmptyState">
+                  <h1>No Chatrooms</h1>
+                  <p>Add a chatroom by using "CTRL"+"t" or clicking Add button</p>
+                </div>
+              )}
+            </Panel>
+
+            {splitPaneChatrooms.map((chatroomId, index) => (
+              <Fragment key={chatroomId}>
+                <PanelResizeHandle className="resize-handle" />
+                <Panel defaultSize={40 / splitPaneChatrooms.length} minSize={20}>
+                  <SplitPaneChat
+                    chatroomId={chatroomId}
+                    kickUsername={kickUsername}
+                    kickId={kickId}
+                    settings={settings}
+                    updateSettings={updateSettings}
+                    onClose={() => removeFromSplitPane(chatroomId)}
+                  />
+                </Panel>
+              </Fragment>
+            ))}
+          </PanelGroup>
         </div>
       </div>
     </div>

--- a/src/renderer/src/providers/ChatProvider.jsx
+++ b/src/renderer/src/providers/ChatProvider.jsx
@@ -397,6 +397,7 @@ const getInitialState = () => {
       chatHistoryLength: DEFAULT_CHAT_HISTORY_LENGTH
     },
     draftMessages: new Map(), // Store draft messages per chatroom
+    splitPaneChatrooms: [], // Store chatroom IDs for split pane view
   };
 };
 
@@ -2289,6 +2290,28 @@ const useChatStore = create((set, get) => ({
 
     // Update local storage
     localStorage.setItem("chatrooms", JSON.stringify(chatroomsWithNewOrder));
+  },
+
+  // Split pane management methods
+  addToSplitPane: (chatroomId) => {
+    set((state) => {
+      if (!state.splitPaneChatrooms.includes(chatroomId)) {
+        return {
+          splitPaneChatrooms: [...state.splitPaneChatrooms, chatroomId],
+        };
+      }
+      return state;
+    });
+  },
+
+  removeFromSplitPane: (chatroomId) => {
+    set((state) => ({
+      splitPaneChatrooms: state.splitPaneChatrooms.filter(id => id !== chatroomId),
+    }));
+  },
+
+  clearSplitPane: () => {
+    set({ splitPaneChatrooms: [] });
   },
 
   handleUserBanned: async (chatroomId, event) => {


### PR DESCRIPTION
## Summary
• Add react-resizable-panels for side-by-side chat viewing
• Implement drag-and-drop from navbar tabs to split zone
• Add split pane state management in ChatProvider
• Create SplitPaneChat component for split panel content
• Add close button functionality for removable panels
• Support flexible panel management where any panel can be closed
• Include proper minimum panel sizes for usable interface
• Fix chat input width for split panel layouts

## Test plan
- [ ] Test dragging chatroom tabs to split zone icon
- [ ] Test resizing panels with proper minimum widths
- [ ] Test closing individual panels and main panel promotion
- [ ] Test with wrapped and non-wrapped navbar layouts
- [ ] Test that chat input width is correct in split panels
- [ ] Test that all existing functionality still works