### PR TITLE
Fix 7TV cosmetics username normalization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,10 @@ MAIN_VITE_OTEL_DIAG_LOG_LEVEL=INFO
 # NORMAL: Above + slow operations (>100ms), startup events, connection changes (default)  
 # VERBOSE: All operations including message parsing, keystroke updates, frequent events
 RENDERER_VITE_TELEMETRY_LEVEL=NORMAL
+# Main-process telemetry log level (controls OTEL IPC relay console output)
+MAIN_VITE_TELEMETRY_LEVEL=NORMAL
+# Toggle extra relay debug logging
+MAIN_VITE_TELEMETRY_DEBUG=false
 
 # Deployment environment flags
 # The app maps MAIN_VITE_OTEL_DEPLOYMENT_ENV => OTEL_DEPLOYMENT_ENV and into OTEL_RESOURCE_ATTRIBUTES.

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -35,7 +35,7 @@ import {
   getUpdateTitle,
   getClearChatroom,
 } from "../../utils/services/kick/kickAPI";
-import { getUserStvProfile, getChannelEmotes } from "../../utils/services/seventv/stvAPI";
+import { getUserStvProfile, getChannelEmotes, getUserCosmetics, getUserCosmeticsById, getAllPaints, getAllBadges, convertPaintToCSS } from "../../utils/services/seventv/stvAPI";
 
 import Store from "electron-store";
 
@@ -498,6 +498,11 @@ if (process.contextIsolated) {
       // 7TV API
       stv: {
         getChannelEmotes,
+        getUserCosmetics,
+        getUserCosmeticsById,
+        getAllPaints,
+        getAllBadges,
+        convertPaintToCSS,
       },
 
       // Utility functions

--- a/src/renderer/src/components/Messages/Message.jsx
+++ b/src/renderer/src/components/Messages/Message.jsx
@@ -41,19 +41,24 @@ const Message = ({
   const getDeleteMessage = useChatStore(useShallow((state) => state.getDeleteMessage));
   const [rightClickedEmote, setRightClickedEmote] = useState(null);
 
-  let userStyle;
+  const senderUsername = message?.sender?.username ?? null;
+  const senderId = message?.sender?.id ?? null;
 
-  if (message?.sender && type !== "replyThread") {
-    if (type === "dialog") {
-      userStyle = dialogUserStyle;
-    } else {
-      userStyle = useCosmeticsStore(
-        useShallow((state) =>
-          state.getUserStyle({ username: message?.sender?.username, userId: message?.sender?.id }),
-        ),
-      );
-    }
-  }
+  const cosmeticsUserStyle = useCosmeticsStore(
+    useShallow((state) => {
+      if (type === "dialog" || type === "replyThread") {
+        return undefined;
+      }
+
+      if (!senderUsername && !senderId) {
+        return undefined;
+      }
+
+      return state.getUserStyle({ username: senderUsername, userId: senderId });
+    }),
+  );
+
+  const userStyle = type === "dialog" ? dialogUserStyle : cosmeticsUserStyle;
 
   // CheckIcon if user can moderate
   const canModerate = useMemo(

--- a/src/renderer/src/components/Messages/Message.jsx
+++ b/src/renderer/src/components/Messages/Message.jsx
@@ -47,7 +47,11 @@ const Message = ({
     if (type === "dialog") {
       userStyle = dialogUserStyle;
     } else {
-      userStyle = useCosmeticsStore(useShallow((state) => state.getUserStyle(message?.sender?.username)));
+      userStyle = useCosmeticsStore(
+        useShallow((state) =>
+          state.getUserStyle({ username: message?.sender?.username, userId: message?.sender?.id }),
+        ),
+      );
     }
   }
 

--- a/src/renderer/src/components/Messages/ModActionMessage.jsx
+++ b/src/renderer/src/components/Messages/ModActionMessage.jsx
@@ -20,7 +20,7 @@ const ModActionMessage = ({ message, chatroomId, allStvEmotes, subscriberBadges,
       const user = await window.app.kick.getUserChatroomInfo(chatroomName, usernameDialog);
       if (!user?.data?.id) return;
 
-      const userStyle = getUserStyle(usernameDialog);
+      const userStyle = getUserStyle({ username: usernameDialog, userId: user?.data?.id });
 
       const userDialogInfo = {
         id: user.data.id,
@@ -42,7 +42,7 @@ const ModActionMessage = ({ message, chatroomId, allStvEmotes, subscriberBadges,
         cords: [0, 300],
       });
     },
-    [chatroomName, username, chatroomId, allStvEmotes, subscriberBadges],
+    [chatroomName, username, chatroomId, allStvEmotes, subscriberBadges, getUserStyle],
   );
 
   return (

--- a/src/renderer/src/providers/ChatProvider.jsx
+++ b/src/renderer/src/providers/ChatProvider.jsx
@@ -908,11 +908,28 @@ const useChatStore = create((set, get) => ({
           useCosmeticsStore?.getState()?.addCosmetics(body);
           break;
         case "entitlement.create": {
-          const username =
-            body?.object?.user?.connections?.find((c) => c.platform === "KICK")?.username ||
-            body?.object?.user?.username;
+          const kickConnection = body?.object?.user?.connections?.find((connection) => {
+            const platform = connection?.platform ?? connection?.type;
+            return platform && String(platform).toUpperCase() === "KICK";
+          });
 
-          useCosmeticsStore?.getState()?.addUserStyle(username, body);
+          const identity = {
+            username:
+              kickConnection?.username ||
+              body?.object?.user?.username ||
+              body?.object?.user?.display_name,
+            userId:
+              kickConnection?.id ??
+              kickConnection?.user_id ??
+              kickConnection?.userId ??
+              kickConnection?.platform_id ??
+              kickConnection?.platformId ??
+              kickConnection?.external_id ??
+              kickConnection?.externalId ??
+              null,
+          };
+
+          useCosmeticsStore?.getState()?.addUserStyle(identity, body);
           break;
         }
 
@@ -1905,10 +1922,27 @@ const useChatStore = create((set, get) => ({
         useCosmeticsStore?.getState()?.addCosmetics(body);
         break;
       case "entitlement.create": {
-        const username =
-          body?.object?.user?.connections?.find((c) => c.platform === "KICK")?.username ||
-          body?.object?.user?.username;
-        useCosmeticsStore?.getState()?.addUserStyle(username, body);
+        const kickConnection = body?.object?.user?.connections?.find((connection) => {
+          const platform = connection?.platform ?? connection?.type;
+          return platform && String(platform).toUpperCase() === "KICK";
+        });
+
+        const identity = {
+          username:
+            kickConnection?.username ||
+            body?.object?.user?.username ||
+            body?.object?.user?.display_name,
+          userId:
+            kickConnection?.id ??
+            kickConnection?.user_id ??
+            kickConnection?.userId ??
+            kickConnection?.platform_id ??
+            kickConnection?.platformId ??
+            kickConnection?.external_id ??
+            kickConnection?.externalId ??
+            null,
+        };
+        useCosmeticsStore?.getState()?.addUserStyle(identity, body);
         break;
       }
       default:

--- a/src/renderer/src/providers/ChatProvider.jsx
+++ b/src/renderer/src/providers/ChatProvider.jsx
@@ -907,12 +907,14 @@ const useChatStore = create((set, get) => ({
         case "cosmetic.create":
           useCosmeticsStore?.getState()?.addCosmetics(body);
           break;
-        case "entitlement.create":
-          const username = body?.object?.user?.connections?.find((c) => c.platform === "KICK")?.username;
-          const transformedUsername = username?.replaceAll("-", "_").toLowerCase();
+        case "entitlement.create": {
+          const username =
+            body?.object?.user?.connections?.find((c) => c.platform === "KICK")?.username ||
+            body?.object?.user?.username;
 
-          useCosmeticsStore?.getState()?.addUserStyle(transformedUsername, body);
+          useCosmeticsStore?.getState()?.addUserStyle(username, body);
           break;
+        }
 
         default:
           break;
@@ -1903,9 +1905,10 @@ const useChatStore = create((set, get) => ({
         useCosmeticsStore?.getState()?.addCosmetics(body);
         break;
       case "entitlement.create": {
-        const username = body?.object?.user?.connections?.find((c) => c.platform === "KICK")?.username;
-        const transformedUsername = username?.replaceAll("-", "_").toLowerCase();
-        useCosmeticsStore?.getState()?.addUserStyle(transformedUsername, body);
+        const username =
+          body?.object?.user?.connections?.find((c) => c.platform === "KICK")?.username ||
+          body?.object?.user?.username;
+        useCosmeticsStore?.getState()?.addUserStyle(username, body);
         break;
       }
       default:

--- a/src/renderer/src/providers/CosmeticsProvider.jsx
+++ b/src/renderer/src/providers/CosmeticsProvider.jsx
@@ -26,6 +26,164 @@ const isKickConnection = (connection) => {
   return String(platform).toUpperCase() === "KICK";
 };
 
+const paintCssCache = new Map();
+const colorCssCache = new Map();
+const badgeCache = new Map();
+let paintDefinitionMap = new Map();
+let badgeDefinitionMap = new Map();
+let globalCosmeticsPromise = null;
+
+// LRU Cache for user style associations
+class LRUCache {
+  constructor(maxSize = 300) {
+    this.maxSize = maxSize;
+    this.cache = new Map();
+  }
+
+  get(key) {
+    if (this.cache.has(key)) {
+      // Move to end (most recently used)
+      const value = this.cache.get(key);
+      this.cache.delete(key);
+      this.cache.set(key, value);
+      return value;
+    }
+    return null;
+  }
+
+  set(key, value) {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.maxSize) {
+      // Remove oldest (first key)
+      const firstKey = this.cache.keys().next().value;
+      this.cache.delete(firstKey);
+    }
+    this.cache.set(key, value);
+  }
+
+  has(key) {
+    return this.cache.has(key);
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+
+  size() {
+    return this.cache.size;
+  }
+}
+
+// Temporarily disabled LRU cache due to memory leak
+// const userStylesCache = new LRUCache(300);
+// const kickTo7tvIdCache = new LRUCache(500);
+// const callTracker = new Map();
+
+const normalizeCosmeticId = (id) => {
+  if (!id) return null;
+  return String(id).replace(/^badge:/i, "").replace(/^paint:/i, "").trim() || null;
+};
+
+const extractKickConnectionInfo = (userStyle) => {
+  if (!userStyle || !Array.isArray(userStyle.connections)) return { id: null, username: null };
+  const connection = userStyle.connections.find(isKickConnection);
+  if (!connection) return { id: null, username: null };
+
+  const kickId =
+    connection.id ??
+    connection.user_id ??
+    connection.userId ??
+    connection.platform_id ??
+    connection.platformId ??
+    connection.external_id ??
+    connection.externalId ??
+    null;
+
+  const username =
+    connection.username ??
+    connection.display_name ??
+    connection.slug ??
+    null;
+
+  return {
+    id: normalizeUserId(kickId),
+    username,
+    normalizedUsername: normalizeUsername(username),
+  };
+};
+
+const extractBadgeId = (style, userStyle, body) => {
+  const direct =
+    style?.badge_id ??
+    style?.badge?.id ??
+    userStyle?.badge_id ??
+    userStyle?.badge?.id ??
+    null;
+  if (direct) return direct;
+
+  const bodyBadge =
+    body?.object?.badge?.id ??
+    body?.badge?.id ??
+    body?.object?.user?.style?.badge?.id ??
+    null;
+  if (bodyBadge) return bodyBadge;
+
+  const badgeCollections = [
+    userStyle?.badges,
+    body?.object?.badges,
+    style?.badges,
+    userStyle?.style?.badges,
+    body?.badges,
+    body?.object?.user?.badges,
+  ];
+
+  for (const collection of badgeCollections) {
+    if (!Array.isArray(collection)) continue;
+    const entry = collection.find((item) => item?.selected) ?? collection[0];
+    if (!entry) continue;
+    if (entry?.badge?.id) return entry.badge.id;
+    if (entry?.id) return entry.id;
+  }
+
+  return null;
+};
+
+const extractPaintId = (style, userStyle, body) => {
+  const direct =
+    style?.paint_id ??
+    style?.paint?.id ??
+    userStyle?.paint_id ??
+    userStyle?.paint?.id ??
+    null;
+  if (direct) return direct;
+
+  const bodyPaint =
+    body?.object?.paint?.id ??
+    body?.paint?.id ??
+    body?.object?.user?.style?.paint?.id ??
+    null;
+  if (bodyPaint) return bodyPaint;
+
+  const paintCollections = [
+    userStyle?.paints,
+    style?.paints,
+    body?.object?.paints,
+    body?.paints,
+    body?.object?.user?.paints,
+  ];
+
+  for (const collection of paintCollections) {
+    if (!Array.isArray(collection)) continue;
+    const entry = collection.find((item) => item?.selected) ?? collection[0];
+    if (!entry) continue;
+    if (entry?.paint?.id) return entry.paint.id;
+    if (entry?.id) return entry.id;
+  }
+
+  return null;
+};
+
 const extractIdentityFields = (identity) => {
   if (!identity && identity !== 0) {
     return { username: null, userId: null };
@@ -95,6 +253,9 @@ const useCosmeticsStore = create((set, get) => ({
     badges: [],
     paints: [],
   },
+  pendingRequests: new Set(),
+  resolvedNoStyle: new Set(),
+  cosmeticsLoaded: false,
 
   addUserStyle: async (identity, body) => {
     const userStyle = body?.object?.user;
@@ -102,30 +263,32 @@ const useCosmeticsStore = create((set, get) => ({
     if (!style) return;
 
     const { username: providedUsername, userId: providedUserId } = extractIdentityFields(identity);
-    const kickConnection = Array.isArray(userStyle?.connections)
-      ? userStyle.connections.find(isKickConnection)
-      : null;
+    const kickConnectionInfo = extractKickConnectionInfo(userStyle);
 
     const fallbackUsername =
       providedUsername ??
-      kickConnection?.username ??
+      kickConnectionInfo.username ??
       userStyle?.username ??
       userStyle?.display_name;
     const usernameKey = normalizeUsername(fallbackUsername);
 
     const resolvedKickUserId =
       providedUserId ??
-      kickConnection?.id ??
-      kickConnection?.user_id ??
-      kickConnection?.userId ??
-      kickConnection?.platform_id ??
-      kickConnection?.platformId ??
-      kickConnection?.external_id ??
-      kickConnection?.externalId ??
+      kickConnectionInfo.id ??
       null;
     const userIdKey = createUserIdKey(resolvedKickUserId);
 
     if (!usernameKey && !userIdKey) return;
+
+    const badgeIdRaw = extractBadgeId(style, userStyle, body);
+    const paintIdRaw = extractPaintId(style, userStyle, body);
+    const normalizedBadgeId = normalizeCosmeticId(badgeIdRaw);
+    const normalizedPaintId = normalizeCosmeticId(paintIdRaw);
+
+    const hasBadge = Boolean(normalizedBadgeId);
+    const hasPaint = Boolean(normalizedPaintId);
+    const hasColor = style.color !== null && style.color !== undefined;
+    const hasStyleData = hasBadge || hasPaint || hasColor;
 
     set((state) => {
       const existingStyle =
@@ -135,10 +298,48 @@ const useCosmeticsStore = create((set, get) => ({
       const hasUsernameMapping = usernameKey ? Boolean(state.userStyles[usernameKey]) : false;
       const hasIdMapping = userIdKey ? Boolean(state.userStyles[userIdKey]) : false;
 
+      let nextResolved = state.resolvedNoStyle;
+
+      if (!hasStyleData) {
+        const record = {
+          badgeId: null,
+          paintId: null,
+          color: null,
+          userId: userStyle.id,
+          kickUserId: normalizeUserId(resolvedKickUserId),
+          username: fallbackUsername ?? userStyle.username,
+          stvUsername: userStyle.username,
+          updatedAt: new Date().toISOString(),
+          noStyle: true,
+        };
+
+        const updatedStyles = { ...state.userStyles };
+        if (usernameKey) {
+          updatedStyles[usernameKey] = record;
+        }
+        if (userIdKey) {
+          updatedStyles[userIdKey] = record;
+        }
+
+        nextResolved = new Set(state.resolvedNoStyle);
+        if (usernameKey) nextResolved.add(usernameKey);
+        if (userIdKey) nextResolved.add(userIdKey);
+
+        console.debug("[Cosmetics] user has no 7TV style", {
+          usernameKey,
+          userIdKey,
+        });
+
+        return {
+          userStyles: updatedStyles,
+          resolvedNoStyle: nextResolved,
+        };
+      }
+
       if (
         existingStyle &&
-        existingStyle.badgeId === style.badge_id &&
-        existingStyle.paintId === style.paint_id &&
+        existingStyle.badgeId === normalizedBadgeId &&
+        existingStyle.paintId === normalizedPaintId &&
         existingStyle.color === style.color &&
         (!usernameKey || hasUsernameMapping) &&
         (!userIdKey || hasIdMapping)
@@ -146,17 +347,17 @@ const useCosmeticsStore = create((set, get) => ({
         return state;
       }
 
+      // Create fallback badge/paint objects if needed
       const styleRecord = {
-        badgeId: style.badge_id,
-        paintId: style.paint_id,
+        badgeId: normalizedBadgeId,
+        paintId: normalizedPaintId,
         color: style.color,
-        kickConnection,
-        entitlement: body,
         userId: userStyle.id,
         kickUserId: normalizeUserId(resolvedKickUserId),
         username: fallbackUsername ?? userStyle.username,
         stvUsername: userStyle.username,
         updatedAt: new Date().toISOString(),
+        noStyle: false,
       };
 
       const updatedStyles = { ...state.userStyles };
@@ -167,16 +368,164 @@ const useCosmeticsStore = create((set, get) => ({
         updatedStyles[userIdKey] = styleRecord;
       }
 
-      return { userStyles: updatedStyles };
+      if (usernameKey || userIdKey) {
+        nextResolved = new Set(state.resolvedNoStyle);
+        if (usernameKey) nextResolved.delete(usernameKey);
+        if (userIdKey) nextResolved.delete(userIdKey);
+      }
+
+      console.debug("[Cosmetics] stored user style", {
+        usernameKey,
+        userIdKey,
+        badgeId: styleRecord.badgeId,
+        paintId: styleRecord.paintId,
+        rawBadgeId: badgeIdRaw,
+        rawPaintId: paintIdRaw,
+        hasExistingStyle: Boolean(existingStyle),
+      });
+
+      return {
+        userStyles: updatedStyles,
+        resolvedNoStyle: nextResolved,
+      };
     });
   },
 
   getUserStyle: (identity) => {
     const storedStyle = resolveStoredStyle(identity, get().userStyles);
-    if (!storedStyle?.badgeId && !storedStyle?.paintId) return null;
+    if (!storedStyle?.badgeId && !storedStyle?.paintId && !storedStyle?.color) return null;
 
-    const badge = get().globalCosmetics?.badges?.find((b) => b.id === storedStyle.badgeId);
-    const paint = get().globalCosmetics?.paints?.find((p) => p.id === storedStyle.paintId);
+    const badgeDefinition = storedStyle.badgeId
+      ? badgeDefinitionMap.get(storedStyle.badgeId) ?? get().globalCosmetics?.badges?.find((b) => b.id === storedStyle.badgeId) ?? null
+      : null;
+
+    const paintDefinition = storedStyle.paintId
+      ? paintDefinitionMap.get(storedStyle.paintId) ?? get().globalCosmetics?.paints?.find((p) => p.id === storedStyle.paintId) ?? null
+      : null;
+
+    if (badgeDefinition && !badgeDefinitionMap.has(badgeDefinition.id)) {
+      badgeDefinitionMap.set(badgeDefinition.id, badgeDefinition);
+    }
+    if (paintDefinition && !paintDefinitionMap.has(paintDefinition.id)) {
+      paintDefinitionMap.set(paintDefinition.id, paintDefinition);
+    }
+
+    // Convert paint definition to CSS
+    let paint = null;
+    if (paintDefinition) {
+      const stvApi = typeof window !== "undefined" ? window.app?.stv : null;
+      if (stvApi?.convertPaintToCSS) {
+        const cached = paintCssCache.get(paintDefinition.id);
+        if (cached && cached.source === paintDefinition) {
+          paint = cached.value;
+        } else {
+          const cssPaint = stvApi.convertPaintToCSS(paintDefinition);
+          const normalizedPaint = cssPaint && (cssPaint.backgroundImage || cssPaint.boxShadow)
+            ? Object.freeze({
+                id: paintDefinition.id,
+                name: paintDefinition.name,
+                backgroundImage: cssPaint.backgroundImage ?? null,
+                shadows: cssPaint.boxShadow ?? null,
+              })
+            : null;
+
+          paintCssCache.set(paintDefinition.id, {
+            source: paintDefinition,
+            value: normalizedPaint,
+          });
+
+          paint = normalizedPaint;
+        }
+      }
+    }
+
+    const badge = (() => {
+      if (storedStyle.badgeId) {
+        console.debug("[Cosmetics] resolving badge", {
+          badgeId: storedStyle.badgeId,
+          hasDefinition: Boolean(badgeDefinition),
+        });
+      }
+      if (!badgeDefinition) return null;
+
+      const cachedBadge = badgeCache.get(badgeDefinition.id);
+      if (cachedBadge && cachedBadge.source === badgeDefinition) {
+        return cachedBadge.value;
+      }
+
+      const image =
+        badgeDefinition.images?.find((img) => img.scale === 3 && img?.url) ||
+        badgeDefinition.images?.find((img) => img.scale === 2 && img?.url) ||
+        badgeDefinition.images?.find((img) => img?.url) ||
+        null;
+
+      let imageUrl = image?.url ?? null;
+
+      if (!imageUrl && badgeDefinition.image?.url) {
+        imageUrl = badgeDefinition.image.url;
+      }
+
+      if (!imageUrl && Array.isArray(badgeDefinition.host?.files)) {
+        const hostFile =
+          badgeDefinition.host.files.find((file) => file.format === "WEBP" && file?.url) ||
+          badgeDefinition.host.files[0];
+        if (hostFile?.url) {
+          imageUrl = hostFile.url;
+        }
+      }
+
+      if (!imageUrl) {
+        console.warn("[Cosmetics] badge definition missing image", {
+          badgeId: badgeDefinition.id,
+          badgeDefinition,
+        });
+        badgeCache.set(badgeDefinition.id, { source: badgeDefinition, value: null });
+        return null;
+      }
+
+      const normalizedBadge = Object.freeze({
+        id: badgeDefinition.id,
+        type: badgeDefinition.id,
+        title: badgeDefinition.tooltip ?? badgeDefinition.name,
+        name: badgeDefinition.name,
+        tooltip: badgeDefinition.tooltip ?? badgeDefinition.name,
+        url: imageUrl,
+      });
+
+      badgeCache.set(badgeDefinition.id, { source: badgeDefinition, value: normalizedBadge });
+      console.debug("[Cosmetics] normalized 7TV badge", {
+        id: normalizedBadge.id,
+        url: normalizedBadge.url,
+        name: normalizedBadge.name,
+      });
+      return normalizedBadge;
+    })();
+
+    // Fallback for users with only color field (no paint_id)
+    if (!paint && storedStyle.color && !storedStyle.paintId) {
+      const convertColorToHex = (colorInt) => {
+        if (colorInt == null) return null;
+        const unsignedColor = (colorInt >>> 0) & 0xFFFFFF;
+        return '#' + unsignedColor.toString(16).padStart(6, '0');
+      };
+
+      const colorHex = convertColorToHex(storedStyle.color);
+      if (colorHex) {
+        const cachedColor = colorCssCache.get(colorHex);
+        if (cachedColor) {
+          paint = cachedColor;
+        } else {
+          const colorPaint = Object.freeze({
+            id: 'color',
+            name: "7TV Color",
+            backgroundImage: `linear-gradient(90deg, ${colorHex}, ${colorHex}99, ${colorHex})`,
+            shadows: null,
+          });
+          colorCssCache.set(colorHex, colorPaint);
+          paint = colorPaint;
+        }
+      }
+    }
 
     return {
       badge,
@@ -186,24 +535,229 @@ const useCosmeticsStore = create((set, get) => ({
       stvUsername: storedStyle.stvUsername,
       badgeId: storedStyle.badgeId,
       paintId: storedStyle.paintId,
-      kickConnection: storedStyle.kickConnection,
-      entitlement: storedStyle.entitlement,
       userId: storedStyle.userId,
       kickUserId: storedStyle.kickUserId,
       updatedAt: storedStyle.updatedAt,
+      noStyle: storedStyle.noStyle ?? false,
     };
   },
 
-  addCosmetics: (body) => {
-    set(() => {
-      const newState = {
-        globalCosmetics: {
-          ...body,
-        },
-      };
+  loadGlobalCosmetics: async () => {
+    if (get().cosmeticsLoaded) {
+      console.debug("[Cosmetics] Global cosmetics already loaded");
+      return;
+    }
 
-      return newState;
+    if (globalCosmeticsPromise) {
+      await globalCosmeticsPromise;
+      return;
+    }
+
+    const stvApi = typeof window !== "undefined" ? window.app?.stv : null;
+    if (!stvApi?.getAllPaints || !stvApi?.getAllBadges) {
+      console.warn("[Cosmetics] 7TV API bridge missing getAllPaints/getAllBadges");
+      return;
+    }
+
+    console.debug("[Cosmetics] Loading global cosmetics...");
+
+    globalCosmeticsPromise = (async () => {
+      try {
+        const [paints, badges] = await Promise.all([
+          stvApi.getAllPaints(),
+          stvApi.getAllBadges()
+        ]);
+
+        paintCssCache.clear();
+        badgeCache.clear();
+        paintDefinitionMap = new Map(paints.map((paint) => [normalizeCosmeticId(paint.id) ?? paint.id, paint]));
+        badgeDefinitionMap = new Map(badges.map((badge) => [normalizeCosmeticId(badge.id) ?? badge.id, badge]));
+
+        set(() => ({
+          globalCosmetics: {
+            paints,
+            badges,
+          },
+          cosmeticsLoaded: true,
+        }));
+
+        console.debug("[Cosmetics] Global cosmetics loaded", {
+          badges: badges.length,
+          paints: paints.length,
+        });
+      } catch (error) {
+        console.error("[Cosmetics] Failed to load global cosmetics:", error?.message || error);
+      } finally {
+        globalCosmeticsPromise = null;
+      }
+    })();
+
+    await globalCosmeticsPromise;
+  },
+
+  addCosmetics: (body) => {
+    console.debug("[Cosmetics] received global cosmetics payload", {
+      badges: body?.badges?.length,
+      paints: body?.paints?.length,
     });
+
+    const currentCosmetics = get().globalCosmetics ?? {};
+    const paints = Array.isArray(body?.paints) ? body.paints : currentCosmetics.paints ?? [];
+    const badges = Array.isArray(body?.badges) ? body.badges : currentCosmetics.badges ?? [];
+
+    paintCssCache.clear();
+    badgeCache.clear();
+    paintDefinitionMap = new Map(paints.map((paint) => [normalizeCosmeticId(paint.id) ?? paint.id, paint]));
+    badgeDefinitionMap = new Map(badges.map((badge) => [normalizeCosmeticId(badge.id) ?? badge.id, badge]));
+
+    set(() => ({
+      globalCosmetics: {
+        paints,
+        badges,
+      },
+    }));
+  },
+
+  ensureUserStyle: async (identity) => {
+    if (!identity) return null;
+
+    console.debug("[Cosmetics] ensureUserStyle called", {
+      username: identity?.username,
+      userId: identity?.userId ?? identity?.id
+    });
+
+    // Ensure global cosmetics are loaded first
+    await get().loadGlobalCosmetics();
+
+    const existingStyle = resolveStoredStyle(identity, get().userStyles);
+    if (existingStyle?.badgeId || existingStyle?.paintId || existingStyle?.color || existingStyle?.noStyle) {
+      console.debug("[Cosmetics] user style already cached", {
+        username: identity?.username,
+        userId: identity?.userId ?? identity?.id,
+      });
+      return existingStyle;
+    }
+
+    const { usernameKey, userIdKey } = deriveIdentityKeys(identity);
+    const requestKey = userIdKey || usernameKey;
+    if (!requestKey) return existingStyle;
+
+    const resolvedNoStyle = get().resolvedNoStyle;
+    if (
+      (userIdKey && resolvedNoStyle.has(userIdKey)) ||
+      (usernameKey && resolvedNoStyle.has(usernameKey))
+    ) {
+      console.debug("[Cosmetics] skipping 7TV lookup; user resolved without style", {
+        usernameKey,
+        userIdKey,
+      });
+      return existingStyle;
+    }
+
+    if (get().pendingRequests.has(requestKey)) {
+      console.debug("[Cosmetics] request already in-flight", { requestKey });
+      return existingStyle;
+    }
+
+    set((state) => {
+      const nextPending = new Set(state.pendingRequests);
+      nextPending.add(requestKey);
+      return { pendingRequests: nextPending };
+    });
+
+    try {
+      const stvApi = typeof window !== "undefined" ? window.app?.stv : null;
+      if (!stvApi?.getUserCosmetics) {
+        console.warn("[Cosmetics] 7TV API bridge missing getUserCosmetics");
+        return existingStyle;
+      }
+
+      const normalizedUserId = normalizeUserId(identity?.userId ?? identity?.id);
+      const response = await stvApi.getUserCosmetics({
+        username: identity?.username ?? identity?.slug ?? identity?.displayName ?? null,
+        userId: normalizedUserId
+      });
+
+      const userData = response?.user ?? response ?? null;
+
+      if (!userData) {
+        set((state) => {
+          const nextResolved = new Set(state.resolvedNoStyle);
+          if (usernameKey) nextResolved.add(usernameKey);
+          if (userIdKey) nextResolved.add(userIdKey);
+          return { resolvedNoStyle: nextResolved };
+        });
+        console.debug("[Cosmetics] 7TV lookup returned no data", {
+          username: identity?.username,
+          userId: normalizedUserId,
+        });
+        return existingStyle;
+      }
+
+      if (!userData?.style) {
+        console.debug("[Cosmetics] user returned without style", {
+          username: userData?.username ?? identity?.username,
+          userId: normalizedUserId ?? userData?.id,
+        });
+
+        set((state) => {
+          const nextResolved = new Set(state.resolvedNoStyle);
+          if (usernameKey) nextResolved.add(usernameKey);
+          if (userIdKey) nextResolved.add(userIdKey);
+          return { resolvedNoStyle: nextResolved };
+        });
+        return existingStyle;
+      }
+
+      await get().addUserStyle(
+        {
+          username: userData?.username ?? identity?.username,
+          userId: normalizedUserId ?? userData?.id,
+        },
+        { object: { user: userData } },
+      );
+
+      console.debug("[Cosmetics] user style hydrated from 7TV", {
+        username: userData?.username ?? identity?.username,
+        badgeId: userData?.style?.badge_id,
+        paintId: userData?.style?.paint_id,
+      });
+
+      set((state) => {
+        const nextResolved = new Set(state.resolvedNoStyle);
+        if (usernameKey) nextResolved.delete(usernameKey);
+        if (userIdKey) nextResolved.delete(userIdKey);
+        return { resolvedNoStyle: nextResolved };
+      });
+
+      const hydratedStyle = resolveStoredStyle(identity, get().userStyles);
+
+      console.debug("[Cosmetics] resolved hydrated style", {
+        username: identity?.username,
+        userId: identity?.userId ?? identity?.id,
+        badgeResolved: Boolean(hydratedStyle?.badgeId),
+        paintResolved: Boolean(hydratedStyle?.paintId),
+      });
+
+      return hydratedStyle;
+    } catch (error) {
+      console.error("[Cosmetics] Failed to fetch 7TV user style:", error?.message || error);
+      if (error?.response?.status === 404) {
+        set((state) => {
+          const nextResolved = new Set(state.resolvedNoStyle);
+          if (usernameKey) nextResolved.add(usernameKey);
+          if (userIdKey) nextResolved.add(userIdKey);
+          return { resolvedNoStyle: nextResolved };
+        });
+      }
+      return existingStyle;
+    } finally {
+      set((state) => {
+        const nextPending = new Set(state.pendingRequests);
+        nextPending.delete(requestKey);
+        return { pendingRequests: nextPending };
+      });
+    }
   },
 
   getUserBadge: (identity) => {

--- a/src/renderer/src/providers/CosmeticsProvider.jsx
+++ b/src/renderer/src/providers/CosmeticsProvider.jsx
@@ -2,7 +2,91 @@ import { create } from "zustand";
 
 const normalizeUsername = (username) => {
   if (!username || typeof username !== "string") return null;
-  return username.replaceAll("-", "_").toLowerCase();
+  const trimmed = username.trim();
+  if (!trimmed) return null;
+  return trimmed.replaceAll("-", "_").toLowerCase();
+};
+
+const normalizeUserId = (userId) => {
+  if (userId === null || userId === undefined) return null;
+  const value = typeof userId === "number" ? String(userId) : `${userId}`;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+};
+
+const createUserIdKey = (userId) => {
+  const normalized = normalizeUserId(userId);
+  return normalized ? `id:${normalized}` : null;
+};
+
+const isKickConnection = (connection) => {
+  if (!connection) return false;
+  const platform = connection.platform ?? connection.type;
+  if (!platform) return false;
+  return String(platform).toUpperCase() === "KICK";
+};
+
+const extractIdentityFields = (identity) => {
+  if (!identity && identity !== 0) {
+    return { username: null, userId: null };
+  }
+
+  if (typeof identity === "string") {
+    return { username: identity, userId: null };
+  }
+
+  if (typeof identity === "number") {
+    return { username: null, userId: identity };
+  }
+
+  if (Array.isArray(identity)) {
+    const [usernameCandidate, userIdCandidate] = identity;
+    return { username: usernameCandidate ?? null, userId: userIdCandidate ?? null };
+  }
+
+  if (typeof identity === "object") {
+    const usernameCandidate =
+      identity.username ??
+      identity.slug ??
+      identity.name ??
+      identity.displayName ??
+      identity?.sender?.username ??
+      identity?.user?.username ??
+      null;
+
+    const userIdCandidate =
+      identity.userId ??
+      identity.id ??
+      identity.user_id ??
+      identity.kickUserId ??
+      identity.kick_id ??
+      identity?.sender?.id ??
+      identity?.user?.id ??
+      null;
+
+    return { username: usernameCandidate ?? null, userId: userIdCandidate ?? null };
+  }
+
+  return { username: null, userId: null };
+};
+
+const deriveIdentityKeys = (identity) => {
+  const { username, userId } = extractIdentityFields(identity);
+  return {
+    usernameKey: normalizeUsername(username),
+    userIdKey: createUserIdKey(userId),
+  };
+};
+
+const resolveStoredStyle = (identity, userStyles) => {
+  if (!userStyles) return null;
+
+  const { usernameKey, userIdKey } = deriveIdentityKeys(identity);
+  return (
+    (userIdKey && userStyles[userIdKey]) ||
+    (usernameKey && userStyles[usernameKey]) ||
+    null
+  );
 };
 
 const useCosmeticsStore = create((set, get) => ({
@@ -12,58 +96,101 @@ const useCosmeticsStore = create((set, get) => ({
     paints: [],
   },
 
-  addUserStyle: async (username, body) => {
+  addUserStyle: async (identity, body) => {
     const userStyle = body?.object?.user;
     const style = userStyle?.style;
     if (!style) return;
 
-    const fallbackUsername = username || userStyle?.username || userStyle?.display_name;
-    const transformedUsername = normalizeUsername(fallbackUsername);
-    if (!transformedUsername) return;
+    const { username: providedUsername, userId: providedUserId } = extractIdentityFields(identity);
+    const kickConnection = Array.isArray(userStyle?.connections)
+      ? userStyle.connections.find(isKickConnection)
+      : null;
+
+    const fallbackUsername =
+      providedUsername ??
+      kickConnection?.username ??
+      userStyle?.username ??
+      userStyle?.display_name;
+    const usernameKey = normalizeUsername(fallbackUsername);
+
+    const resolvedKickUserId =
+      providedUserId ??
+      kickConnection?.id ??
+      kickConnection?.user_id ??
+      kickConnection?.userId ??
+      kickConnection?.platform_id ??
+      kickConnection?.platformId ??
+      kickConnection?.external_id ??
+      kickConnection?.externalId ??
+      null;
+    const userIdKey = createUserIdKey(resolvedKickUserId);
+
+    if (!usernameKey && !userIdKey) return;
 
     set((state) => {
-      const currentStyle = state.userStyles[transformedUsername] || {};
+      const existingStyle =
+        (userIdKey && state.userStyles[userIdKey]) ||
+        (usernameKey && state.userStyles[usernameKey]) ||
+        null;
+      const hasUsernameMapping = usernameKey ? Boolean(state.userStyles[usernameKey]) : false;
+      const hasIdMapping = userIdKey ? Boolean(state.userStyles[userIdKey]) : false;
+
       if (
-        currentStyle.badgeId === style.badge_id &&
-        currentStyle.paintId === style.paint_id &&
-        currentStyle.color === style.color
+        existingStyle &&
+        existingStyle.badgeId === style.badge_id &&
+        existingStyle.paintId === style.paint_id &&
+        existingStyle.color === style.color &&
+        (!usernameKey || hasUsernameMapping) &&
+        (!userIdKey || hasIdMapping)
       ) {
         return state;
       }
 
-      return {
-        userStyles: {
-          ...state.userStyles,
-          [transformedUsername]: {
-            badgeId: style.badge_id,
-            paintId: style.paint_id,
-            color: style.color,
-            kickConnection: userStyle.connections?.find((c) => c.type === "KICK" || c.platform === "KICK"),
-            entitlement: body,
-            userId: userStyle.id,
-            username: userStyle.username,
-            updatedAt: new Date().toISOString(),
-          },
-        },
+      const styleRecord = {
+        badgeId: style.badge_id,
+        paintId: style.paint_id,
+        color: style.color,
+        kickConnection,
+        entitlement: body,
+        userId: userStyle.id,
+        kickUserId: normalizeUserId(resolvedKickUserId),
+        username: fallbackUsername ?? userStyle.username,
+        stvUsername: userStyle.username,
+        updatedAt: new Date().toISOString(),
       };
+
+      const updatedStyles = { ...state.userStyles };
+      if (usernameKey) {
+        updatedStyles[usernameKey] = styleRecord;
+      }
+      if (userIdKey) {
+        updatedStyles[userIdKey] = styleRecord;
+      }
+
+      return { userStyles: updatedStyles };
     });
   },
 
-  getUserStyle: (username) => {
-    const transformedUsername = normalizeUsername(username);
-    if (!transformedUsername) return null;
-    const userStyle = get().userStyles[transformedUsername];
+  getUserStyle: (identity) => {
+    const storedStyle = resolveStoredStyle(identity, get().userStyles);
+    if (!storedStyle?.badgeId && !storedStyle?.paintId) return null;
 
-    if (!userStyle?.badgeId && !userStyle?.paintId) return null;
-
-    const badge = get().globalCosmetics?.badges?.find((b) => b.id === userStyle.badgeId);
-    const paint = get().globalCosmetics?.paints?.find((p) => p.id === userStyle.paintId);
+    const badge = get().globalCosmetics?.badges?.find((b) => b.id === storedStyle.badgeId);
+    const paint = get().globalCosmetics?.paints?.find((p) => p.id === storedStyle.paintId);
 
     return {
       badge,
       paint,
-      color: userStyle.color,
-      username: userStyle.username,
+      color: storedStyle.color,
+      username: storedStyle.username,
+      stvUsername: storedStyle.stvUsername,
+      badgeId: storedStyle.badgeId,
+      paintId: storedStyle.paintId,
+      kickConnection: storedStyle.kickConnection,
+      entitlement: storedStyle.entitlement,
+      userId: storedStyle.userId,
+      kickUserId: storedStyle.kickUserId,
+      updatedAt: storedStyle.updatedAt,
     };
   },
 
@@ -79,24 +206,18 @@ const useCosmeticsStore = create((set, get) => ({
     });
   },
 
-  getUserBadge: (username) => {
-    const transformedUsername = normalizeUsername(username);
-    if (!transformedUsername) return null;
+  getUserBadge: (identity) => {
+    const storedStyle = resolveStoredStyle(identity, get().userStyles);
+    if (!storedStyle?.badgeId) return null;
 
-    const userStyle = get().userStyles[transformedUsername];
-    if (!userStyle?.badgeId) return null;
-
-    return get().globalCosmetics?.badges?.find((badge) => badge.id === userStyle.badgeId) || null;
+    return get().globalCosmetics?.badges?.find((badge) => badge.id === storedStyle.badgeId) || null;
   },
 
-  getUserPaint: (username) => {
-    const transformedUsername = normalizeUsername(username);
-    if (!transformedUsername) return null;
+  getUserPaint: (identity) => {
+    const storedStyle = resolveStoredStyle(identity, get().userStyles);
+    if (!storedStyle?.paintId) return null;
 
-    const userStyle = get().userStyles[transformedUsername];
-    if (!userStyle?.paintId) return null;
-
-    return get().globalCosmetics?.paints?.find((paint) => paint.id === userStyle.paintId) || null;
+    return get().globalCosmetics?.paints?.find((paint) => paint.id === storedStyle.paintId) || null;
   },
 }));
 

--- a/src/renderer/src/providers/CosmeticsProvider.jsx
+++ b/src/renderer/src/providers/CosmeticsProvider.jsx
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 
+const normalizeUsername = (username) => {
+  if (!username || typeof username !== "string") return null;
+  return username.replaceAll("-", "_").toLowerCase();
+};
+
 const useCosmeticsStore = create((set, get) => ({
   userStyles: {},
   globalCosmetics: {
@@ -8,23 +13,32 @@ const useCosmeticsStore = create((set, get) => ({
   },
 
   addUserStyle: async (username, body) => {
-    if (!body?.object?.user?.style) return;
-    const transformedUsername = username.toLowerCase();
-    const userStyle = body.object.user;
+    const userStyle = body?.object?.user;
+    const style = userStyle?.style;
+    if (!style) return;
+
+    const fallbackUsername = username || userStyle?.username || userStyle?.display_name;
+    const transformedUsername = normalizeUsername(fallbackUsername);
+    if (!transformedUsername) return;
 
     set((state) => {
       const currentStyle = state.userStyles[transformedUsername] || {};
-      if (currentStyle.badgeId === body.object.user.style.badge_id && currentStyle.paintId === body.object.user.style.paint_id)
+      if (
+        currentStyle.badgeId === style.badge_id &&
+        currentStyle.paintId === style.paint_id &&
+        currentStyle.color === style.color
+      ) {
         return state;
+      }
 
       return {
         userStyles: {
           ...state.userStyles,
           [transformedUsername]: {
-            badgeId: userStyle.style.badge_id,
-            paintId: userStyle.style.paint_id,
-            color: userStyle.style.color,
-            kickConnection: userStyle.connections?.find((c) => c.type === "KICK"),
+            badgeId: style.badge_id,
+            paintId: style.paint_id,
+            color: style.color,
+            kickConnection: userStyle.connections?.find((c) => c.type === "KICK" || c.platform === "KICK"),
             entitlement: body,
             userId: userStyle.id,
             username: userStyle.username,
@@ -36,8 +50,8 @@ const useCosmeticsStore = create((set, get) => ({
   },
 
   getUserStyle: (username) => {
-    if (!username) return null;
-    const transformedUsername = username.toLowerCase();
+    const transformedUsername = normalizeUsername(username);
+    if (!transformedUsername) return null;
     const userStyle = get().userStyles[transformedUsername];
 
     if (!userStyle?.badgeId && !userStyle?.paintId) return null;
@@ -66,21 +80,23 @@ const useCosmeticsStore = create((set, get) => ({
   },
 
   getUserBadge: (username) => {
-    const transformedUsername = username.toLowerCase();
+    const transformedUsername = normalizeUsername(username);
+    if (!transformedUsername) return null;
 
     const userStyle = get().userStyles[transformedUsername];
     if (!userStyle?.badgeId) return null;
 
-    return get().globalCosmetics[userStyle.badgeId];
+    return get().globalCosmetics?.badges?.find((badge) => badge.id === userStyle.badgeId) || null;
   },
 
   getUserPaint: (username) => {
-    const transformedUsername = username.toLowerCase();
+    const transformedUsername = normalizeUsername(username);
+    if (!transformedUsername) return null;
 
     const userStyle = get().userStyles[transformedUsername];
     if (!userStyle?.paintId) return null;
 
-    return get().globalCosmetics[userStyle.paintId];
+    return get().globalCosmetics?.paints?.find((paint) => paint.id === userStyle.paintId) || null;
   },
 }));
 


### PR DESCRIPTION
## Summary
- normalize Kick usernames in the cosmetics store so 7TV badges and paints map consistently
- fall back to user-provided names when handling 7TV entitlement events to populate cosmetics for more accounts
- tighten cosmetics badge/paint lookup helpers for future use

## Testing
- npm run lint *(warns due to existing unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68cca299ffc883319ca4a68bf9ed41eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded cosmetics support: broader paint/badge loading and conversion for richer user styling.
  * Renderer now hydrates and resolves user cosmetics automatically when available.

* **Bug Fixes**
  * Consistent styling across real-time and shared message paths for Kick and other platforms.
  * Safer fallbacks to avoid missing or incorrect badges/paints when usernames or IDs are absent.

* **Refactor**
  * Identity-centric cosmetics handling to improve lookup accuracy and reduce UI churn.

* **Chores**
  * Added telemetry configuration flags to environment examples and improved adjustable logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->