### PR TITLE
fix: throttle analytics prompt to monthly

### DIFF
--- a/src/renderer/src/assets/styles/components/Chat/Input.scss
+++ b/src/renderer/src/assets/styles/components/Chat/Input.scss
@@ -43,9 +43,10 @@
   z-index: 1;
 
   > .chatTelemetryPrompt {
+    position: relative;
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: stretch;
     gap: 12px;
     width: calc(100% - 16px);
     margin: 0 8px 8px;
@@ -56,57 +57,82 @@
     color: var(--text-primary);
     animation: slideAndFadeIn 0.2s ease-in-out forwards;
 
-    > .chatTelemetryPromptText {
+    > .chatTelemetryPromptDismiss {
+      position: absolute;
+      top: 8px;
+      right: 8px;
       display: flex;
-      flex-direction: column;
-      gap: 2px;
-      font-size: 13px;
-      line-height: 1.4;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      padding: 0;
+      background: transparent;
+      border-color: transparent;
+      color: var(--text-secondary);
 
-      > strong {
-        font-size: 14px;
+      &:hover {
+        background: var(--bg-hover);
         color: var(--text-primary);
+        border-color: var(--border-hover);
       }
 
-      > span {
-        color: var(--text-secondary);
+      &:focus-visible {
+        outline: 2px solid var(--border-focus);
+        outline-offset: 2px;
       }
     }
 
-    > .chatTelemetryPromptActions {
+    > .chatTelemetryPromptContent {
       display: flex;
-      align-items: center;
-      gap: 8px;
-      flex-wrap: wrap;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 12px;
 
-      > button {
-        cursor: pointer;
-        border-radius: 4px;
-        padding: 4px 10px;
-        font-size: 12px;
-        transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out;
-        border: 1px solid transparent;
-      }
+      > .chatTelemetryPromptText {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 13px;
+        line-height: 1.4;
 
-      > .chatTelemetryPromptEnable {
-        background: var(--btn-primary-bg);
-        color: var(--btn-primary-text);
-        border-color: var(--btn-primary-bg);
+        > strong {
+          font-size: 14px;
+          color: var(--text-primary);
+        }
 
-        &:hover {
-          background: var(--btn-primary-hover);
-          border-color: var(--btn-primary-hover);
+        > span {
+          color: var(--text-secondary);
         }
       }
 
-      > .chatTelemetryPromptDismiss {
-        background: var(--btn-secondary-bg);
-        border-color: var(--btn-secondary-border);
-        color: var(--text-tertiary);
+      > .chatTelemetryPromptActions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 0;
+        flex-shrink: 0;
 
-        &:hover {
-          color: var(--text-primary);
-          border-color: var(--btn-primary-hover);
+        > button {
+          cursor: pointer;
+          border-radius: 4px;
+          padding: 4px 10px;
+          font-size: 12px;
+          white-space: nowrap;
+          transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out;
+          border: 1px solid transparent;
+        }
+
+        > .chatTelemetryPromptEnable {
+          align-self: flex-start;
+          background: var(--btn-primary-bg);
+          color: var(--btn-primary-text);
+          border-color: var(--btn-primary-bg);
+
+          &:hover {
+            background: var(--btn-primary-hover);
+            border-color: var(--btn-primary-hover);
+          }
         }
       }
     }

--- a/src/renderer/src/assets/styles/components/Chat/Input.scss
+++ b/src/renderer/src/assets/styles/components/Chat/Input.scss
@@ -42,6 +42,76 @@
   left: 0;
   z-index: 1;
 
+  > .chatTelemetryPrompt {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    width: calc(100% - 16px);
+    margin: 0 8px 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-secondary);
+    border-radius: 6px;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    animation: slideAndFadeIn 0.2s ease-in-out forwards;
+
+    > .chatTelemetryPromptText {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      font-size: 13px;
+      line-height: 1.4;
+
+      > strong {
+        font-size: 14px;
+        color: var(--text-primary);
+      }
+
+      > span {
+        color: var(--text-secondary);
+      }
+    }
+
+    > .chatTelemetryPromptActions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+
+      > button {
+        cursor: pointer;
+        border-radius: 4px;
+        padding: 4px 10px;
+        font-size: 12px;
+        transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out;
+        border: 1px solid transparent;
+      }
+
+      > .chatTelemetryPromptEnable {
+        background: var(--btn-primary-bg);
+        color: var(--btn-primary-text);
+        border-color: var(--btn-primary-bg);
+
+        &:hover {
+          background: var(--btn-primary-hover);
+          border-color: var(--btn-primary-hover);
+        }
+      }
+
+      > .chatTelemetryPromptDismiss {
+        background: var(--btn-secondary-bg);
+        border-color: var(--btn-secondary-border);
+        color: var(--text-tertiary);
+
+        &:hover {
+          color: var(--text-primary);
+          border-color: var(--btn-primary-hover);
+        }
+      }
+    }
+  }
+
   > .chatInfoBar {
     display: flex;
     align-items: center;

--- a/src/renderer/src/components/Chat/Input/index.jsx
+++ b/src/renderer/src/components/Chat/Input/index.jsx
@@ -1436,24 +1436,26 @@ const ChatInput = memo(
         <div className="chatInputInfoBar">
           {showTelemetryPrompt && (
             <div className="chatTelemetryPrompt" role="alert">
-              <div className="chatTelemetryPromptText">
-                <strong>Help improve KickTalk</strong>
-                <span>Enable analytics so we can understand bugs and improve KickTalk.</span>
-              </div>
-              <div className="chatTelemetryPromptActions">
-                <button
-                  type="button"
-                  className="chatTelemetryPromptEnable"
-                  onClick={handleEnableTelemetry}>
-                  Enable Analytics
-                </button>
-                <button
-                  type="button"
-                  className="chatTelemetryPromptDismiss"
-                  onClick={handleDismissTelemetryPrompt}
-                  aria-label="Dismiss analytics prompt">
-                  Dismiss
-                </button>
+              <button
+                type="button"
+                className="chatTelemetryPromptDismiss"
+                onClick={handleDismissTelemetryPrompt}
+                aria-label="Dismiss analytics prompt">
+                <XIcon size={14} weight="bold" aria-hidden="true" />
+              </button>
+              <div className="chatTelemetryPromptContent">
+                <div className="chatTelemetryPromptText">
+                  <strong>Help improve KickTalk</strong>
+                  <span>Share anonymous usage analytics so we can spot bugs sooner and polish the chat experience.</span>
+                </div>
+                <div className="chatTelemetryPromptActions">
+                  <button
+                    type="button"
+                    className="chatTelemetryPromptEnable"
+                    onClick={handleEnableTelemetry}>
+                    Share Analytics
+                  </button>
+                </div>
               </div>
             </div>
           )}

--- a/src/renderer/src/components/Chat/Input/index.jsx
+++ b/src/renderer/src/components/Chat/Input/index.jsx
@@ -39,6 +39,7 @@ import { MessageParser } from "../../../utils/MessageParser";
 import { isModeEnabled, chatModeMatches } from "../../../utils/ChatUtils";
 import { recordChatModeFeatureUsage } from "../../../telemetry/chatModeTelemetry";
 import { useAccessibleKickEmotes } from "./useAccessibleKickEmotes";
+import { useSettings } from "../../../providers/SettingsProvider";
 
 const onError = (error) => {
   console.error(error);
@@ -116,6 +117,71 @@ const isEmoteOnlyContent = (editor) => {
 };
 
 const messageHistory = new Map();
+
+const TELEMETRY_PROMPT_DISMISSED_KEY = "kicktalk.telemetryPromptDismissed";
+const TELEMETRY_PROMPT_DISMISSAL_TTL_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
+const persistTelemetryPromptDismissal = () => {
+  if (typeof window === "undefined") return null;
+
+  const record = { dismissedAt: new Date().toISOString() };
+
+  try {
+    window.localStorage.setItem(
+      TELEMETRY_PROMPT_DISMISSED_KEY,
+      JSON.stringify(record),
+    );
+  } catch (error) {
+    console.warn("[ChatInput]: Failed to persist telemetry prompt dismissal", error);
+    return null;
+  }
+
+  return record;
+};
+
+const readTelemetryPromptDismissal = () => {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const storedValue = window.localStorage.getItem(TELEMETRY_PROMPT_DISMISSED_KEY);
+    if (!storedValue) return null;
+
+    if (storedValue === "true") {
+      // migrate legacy boolean flag to structured record
+      return persistTelemetryPromptDismissal();
+    }
+
+    try {
+      const parsed = JSON.parse(storedValue);
+      if (parsed?.dismissedAt) {
+        const dismissedAt = new Date(parsed.dismissedAt);
+        if (!Number.isNaN(dismissedAt.getTime())) {
+          return { dismissedAt: dismissedAt.toISOString() };
+        }
+      }
+    } catch {
+      // fall through to attempt parsing a plain ISO string
+    }
+
+    const asDate = new Date(storedValue);
+    if (!Number.isNaN(asDate.getTime())) {
+      const record = { dismissedAt: asDate.toISOString() };
+      try {
+        window.localStorage.setItem(
+          TELEMETRY_PROMPT_DISMISSED_KEY,
+          JSON.stringify(record),
+        );
+      } catch (error) {
+        console.warn("[ChatInput]: Failed to migrate telemetry prompt dismissal", error);
+      }
+      return record;
+    }
+  } catch (error) {
+    console.warn("[ChatInput]: Failed to read telemetry prompt dismissal state", error);
+  }
+
+  return null;
+};
 
 const EmoteSuggestions = memo(
   ({ suggestions, onSelect, selectedIndex, userChatroomInfo }) => {
@@ -1160,6 +1226,7 @@ const ReplyHandler = ({ chatroomId, getReplyData, clearReplyData, allStvEmotes, 
 
 const ChatInput = memo(
   ({ chatroomId, isReplyThread = false, replyMessage = {}, settings }) => {
+    const { updateSettings: updateAppSettings } = useSettings();
     const sendMessage = useChatStore((state) => state.sendMessage);
     const sendReply = useChatStore((state) => state.sendReply);
     const clearDraftMessage = useChatStore((state) => state.clearDraftMessage);
@@ -1182,6 +1249,57 @@ const ChatInput = memo(
     const getReplyData = useCallback(() => replyDataRef.current, []);
 
     const allStvEmotes = useAllStvEmotes(chatroomId);
+
+    const [showTelemetryPrompt, setShowTelemetryPrompt] = useState(false);
+
+    useEffect(() => {
+      if (!settings) {
+        setShowTelemetryPrompt(false);
+        return;
+      }
+
+      if (settings?.telemetry?.enabled) {
+        setShowTelemetryPrompt(false);
+        return;
+      }
+
+      const dismissalRecord = readTelemetryPromptDismissal();
+      if (!dismissalRecord?.dismissedAt) {
+        setShowTelemetryPrompt(true);
+        return;
+      }
+
+      const dismissedAt = new Date(dismissalRecord.dismissedAt);
+      if (Number.isNaN(dismissedAt.getTime())) {
+        setShowTelemetryPrompt(true);
+        return;
+      }
+
+      const now = Date.now();
+      const age = now - dismissedAt.getTime();
+      setShowTelemetryPrompt(age >= TELEMETRY_PROMPT_DISMISSAL_TTL_MS);
+    }, [settings, settings?.telemetry?.enabled]);
+
+    const handleEnableTelemetry = useCallback(async () => {
+      try {
+        await updateAppSettings?.("telemetry", {
+          ...settings?.telemetry,
+          enabled: true,
+        });
+      } catch (error) {
+        console.warn("[ChatInput]: Failed to enable telemetry from prompt", error);
+      }
+
+      persistTelemetryPromptDismissal();
+
+      setShowTelemetryPrompt(false);
+    }, [settings?.telemetry, updateAppSettings]);
+
+    const handleDismissTelemetryPrompt = useCallback(() => {
+      persistTelemetryPromptDismissal();
+
+      setShowTelemetryPrompt(false);
+    }, []);
 
     // Reset selected index when changing chatrooms
     useEffect(() => {
@@ -1316,6 +1434,29 @@ const ChatInput = memo(
     return (
       <div className="chatInputWrapper">
         <div className="chatInputInfoBar">
+          {showTelemetryPrompt && (
+            <div className="chatTelemetryPrompt" role="alert">
+              <div className="chatTelemetryPromptText">
+                <strong>Help improve KickTalk</strong>
+                <span>Enable analytics so we can understand bugs and improve KickTalk.</span>
+              </div>
+              <div className="chatTelemetryPromptActions">
+                <button
+                  type="button"
+                  className="chatTelemetryPromptEnable"
+                  onClick={handleEnableTelemetry}>
+                  Enable Analytics
+                </button>
+                <button
+                  type="button"
+                  className="chatTelemetryPromptDismiss"
+                  onClick={handleDismissTelemetryPrompt}
+                  aria-label="Dismiss analytics prompt">
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          )}
           {settings?.chatrooms?.showInfoBar && (
             <InfoBar chatroomInfo={chatroom?.chatroomInfo} initialChatroomInfo={chatroom?.initialChatroomInfo} />
           )}
@@ -1378,7 +1519,8 @@ const ChatInput = memo(
   (prev, next) =>
     prev.chatroomId === next.chatroomId &&
     prev.replyMessage === next.replyMessage &&
-    prev.settings?.chatrooms?.showInfoBar === next.settings?.chatrooms?.showInfoBar,
+    prev.settings?.chatrooms?.showInfoBar === next.settings?.chatrooms?.showInfoBar &&
+    prev.settings?.telemetry?.enabled === next.settings?.telemetry?.enabled,
 );
 
 export default ChatInput;

--- a/src/renderer/src/components/Dialogs/ReplyThread.jsx
+++ b/src/renderer/src/components/Dialogs/ReplyThread.jsx
@@ -107,7 +107,12 @@ const ReplyThread = () => {
 
         <div className="replyThreadInput">
           {originalMessage?.original_message?.id && (
-            <ChatInput chatroomId={dialogData?.chatroomId} isReplyThread={true} replyMessage={originalMessage} />
+            <ChatInput
+              chatroomId={dialogData?.chatroomId}
+              isReplyThread={true}
+              replyMessage={originalMessage}
+              settings={dialogData?.settings}
+            />
           )}
         </div>
       </div>

--- a/src/renderer/src/dialogs/ReplyThread.jsx
+++ b/src/renderer/src/dialogs/ReplyThread.jsx
@@ -5,5 +5,10 @@ import "@utils/themeUtils";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import ReplyThread from "../components/Dialogs/ReplyThread.jsx";
+import SettingsProvider from "../providers/SettingsProvider.jsx";
 
-ReactDOM.createRoot(document.getElementById("root")).render(<ReplyThread />);
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <SettingsProvider>
+    <ReplyThread />
+  </SettingsProvider>,
+);


### PR DESCRIPTION
## Summary
- add a dismissible analytics prompt alongside the chat info bar
- allow enabling telemetry directly from the chat prompt and persist dismissal state with a 30-day cooldown
- style the new analytics banner to match existing chat input treatments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd7eb25ae4833185a25f5bde706947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an in-app prompt below the chat input to enable analytics, with “Enable Analytics” and “Dismiss” actions; user choice is remembered.

- Improvements
  - Polished styling, hover/focus states, and a slide-and-fade entrance for the prompt; consistent visibility across chats and sessions, respecting prior choices and settings.

- Performance
  - Minor render optimizations to reduce unnecessary re-renders and improve chat input responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->